### PR TITLE
Correcting times

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ tar.pack('source-directory').pipe(tar.extract('dest-directory'))
 Packing and extracting a 6.1 GB with 2496 directories and 2398 files yields the following results on my Macbook Air.
 [See the benchmark here](https://gist.github.com/mafintosh/8102201)
 
-* tar-fs: 34.261 ms
-* [node-tar](https://github.com/isaacs/node-tar): 366.123 ms (or 10x slower)
+* tar-fs: 34.261 sec
+* [node-tar](https://github.com/isaacs/node-tar): 366.123 sec (or 10x slower)
 
 ## License
 


### PR DESCRIPTION
I'm guessing these are supposed to be seconds, not milliseconds.  6.1GB in 32ms would be...fast.