### PR TITLE
Restore the call on utimes on win32 platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,9 +228,9 @@ exports.extract = function (cwd, opts) {
 
     var stat = function (err) {
       if (err) return next(err)
-      if (win32) return next()
       utimes(name, header, function (err) {
         if (err) return next(err)
+        if (win32) return next()
         chperm(name, header, next)
       })
     }

--- a/test/index.js
+++ b/test/index.js
@@ -164,7 +164,7 @@ test('strip + map', function (t) {
 })
 
 test('map + dir + permissions', function (t) {
-  t.plan(2)
+  t.plan(win32 ? 1 : 2) // skip chmod test, it's not working like unix
 
   var a = path.join(__dirname, 'fixtures', 'b')
   var b = path.join(__dirname, 'fixtures', 'copy', 'a-perms')
@@ -184,7 +184,9 @@ test('map + dir + permissions', function (t) {
         var files = fs.readdirSync(b).sort()
         var stat = fs.statSync(path.join(b, 'a'))
         t.same(files.length, 1)
-        t.same(stat.mode & parseInt(777, 8), parseInt(700, 8))
+        if (!win32) {
+          t.same(stat.mode & parseInt(777, 8), parseInt(700, 8))
+        }
       })
 })
 


### PR DESCRIPTION
It was reverted by
https://github.com/mafintosh/tar-fs/commit/b49550a02b3cff04af8b1dd793eca917d1230873


Please, note that the tests fail because it seems that the utimes on win32 has not the same precision that on unices.

```
$ npm test

> tar-fs@1.9.0 test S:\devel\tar-fs
> standard && tape test/index.js

TAP version 13
# copy a -> copy/a
ok 1 should be equivalent
ok 2 should be equivalent
ok 3 should be equivalent
ok 4 should be equivalent
not ok 5 should be equivalent
  ---
    operator: deepEqual
    expected: 1454945070238
    actual:   1454945070000
  ...
# copy b -> copy/b
ok 6 should be equivalent
ok 7 should be equivalent
ok 8 should be equivalent
not ok 9 should be equivalent
  ---
    operator: deepEqual
    expected: 1454945070238
    actual:   1454945070000
  ...
ok 10 (unnamed assert)
ok 11 should be equivalent
ok 12 should be equivalent
not ok 13 should be equivalent
  ---
    operator: deepEqual
    expected: 1454945070239
    actual:   1454945070000
  ...
# symlink
ok 14 (unnamed assert)
# follow symlinks
ok 15 (unnamed assert)
# strip
ok 16 should be equivalent
ok 17 should be equivalent
# strip + map
ok 18 should be equivalent
ok 19 should be equivalent
# map + dir + permissions
ok 20 should be equivalent
not ok 21 should be equivalent
  ---
    operator: deepEqual
    expected: 448
    actual:   438
  ...
# specific entries
ok 22 should be equivalent
ok 23 should not be equivalent
ok 24 should not be equivalent
ok 25 should not be equivalent
ok 26 should be equivalent
ok 27 should be equivalent

1..27
# tests 27
# pass  23
# fail  4

npm ERR! Test failed.  See above for more details.
```

According to msdn, it should be 100-ns https://msdn.microsoft.com/en-us/library/windows/desktop/ms724290(v=vs.85).aspx but here it looks like just a precision of the second.