### PR TITLE
Ignore before mapping.

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,6 @@ exports.extract = function (cwd, opts) {
   }
 
   extract.on('entry', function (header, stream, next) {
-    header = map(header) || header
     header.name = normalize(header.name)
     var name = path.join(cwd, path.join('/', header.name))
 
@@ -227,6 +226,9 @@ exports.extract = function (cwd, opts) {
       stream.resume()
       return next()
     }
+
+    header = map(header) || header
+    name = path.join(cwd, path.join('/', header.name))
 
     var stat = function (err) {
       if (err) return next(err)


### PR DESCRIPTION
My use case: extract particular files from a tar file based on their folder name and store them in a different folder in the destination folder.
Problem: Because map was being run before ignore, the information about the folder would have been stripped by the time it reached ignore.
Solution: Run ignore before map. 
