### PR TITLE
strip linkname on hard links

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var strip = function (map, level) {
     header.name = header.name.split('/').slice(level).join('/')
 
     var linkname = header.linkname
-    if (linkname && path.isAbsolute(linkname)) {
+    if (linkname && (header.type === 'link' || path.isAbsolute(linkname))) {
       header.linkname = linkname.split('/').slice(level).join('/')
     }
 


### PR DESCRIPTION
It seems hard links are defined using relative paths from the root of the tar file... that absolutely makes sense since it's needed always an absolute reference inside the tar file itself but the initial slash is mostly useless because it will be always there :-P

```
 > tar -tvf syslinux-6.03.tar.gz |grep bios/linux
drwxrwxr-x hpa/hpa           0 2014-10-06 18:32 syslinux-6.03/bios/linux/
-rwxrwxr-x hpa/hpa      213600 2014-10-06 18:32 syslinux-6.03/bios/linux/syslinux-nomtools
hrwxrwxr-x hpa/hpa           0 2014-10-06 18:32 syslinux-6.03/bios/linux/syslinux enlace a syslinux-6.03/bios/linux/syslinux-nomtools
```

Problem is that my previous commit introduced a regression here by not considering this use case. This change now fix it by allways strip `linkname` if it's from a hard link.