### PR TITLE
chown directories too, on extract

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.15.0",
   "description": "filesystem bindings for tar-stream",
   "dependencies": {
+    "chownr": "^1.0.1",
     "mkdirp": "^0.5.0",
     "pump": "^1.0.0",
     "tar-stream": "^1.1.2"


### PR DESCRIPTION
Fixes: #59

The best way I've found to test it might need a few more changes to the project and at least one extra (dev)dependency so I figured I'd poke y'all to see how much you cared or if you have a better idea of how to test this file ownership change stuff.

I have a [test written in the consuming library](https://github.com/zkat/pacote/blob/1834b3aaa743f23b1144d29983b41256f7548cba/test/extract-stream.chown.js) already, which passed when I installed my fork manually, so at least I'm fairly confident about the patch itself. :)