### PR TITLE
Add more special characters for windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var echo = function (name) {
 }
 
 var normalize = !win32 ? echo : function (name) {
-  return name.replace(/\\/g, '/').replace(/:/g, '_')
+  return name.replace(/\\/g, '/').replace(/[:?<>|]/g, '_')
 }
 
 var statAll = function (fs, stat, cwd, ignore, entries, sort) {


### PR DESCRIPTION
Hi guys, 

`tar-fs` is throwing error on Windows when it tries to extract [tgz file](https://registry.npmjs.org/canned/-/canned-0.3.10.tgz) which contains filename with `?`. 

I found this [issue](https://github.com/npm/npm/issues/16882) when I was running `npm install canned` with new npm@5 which uses `tar-fs` for extracting tgz files:
```
enoent ENOENT: no such file or directory, open '...\spec\test_responses\_a?name=Batman&age=30.get.html'
```

You can easily replicate the error using only `tar-fs`:
```js
let tar = require("tar-fs");
let gunzip = require("gunzip-maybe");
let fs = require("fs");

fs.createReadStream('canned-0.3.10.tgz').pipe(gunzip()).pipe(tar.extract('./temp'));
```

I see that you do a small normalization of the filename so I have expanded the list of invalid characters for windows. I used the same list which is also used by `node-tar` package (see [code](https://github.com/npm/node-tar/blob/master/lib/winchars.js)).

After fixing the code, extract function is no longer throwing error and I can see that the file was successfully extracted as `_a_name=Batman&age=30.get.html`.
