### PR TITLE
Add `finalize: false` option to `pack()`, to allow advanced tar stream manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ Copying a directory with permissions and mtime intact is as simple as
 tar.pack('source-directory').pipe(tar.extract('dest-directory'))
 ```
 
+## Interaction with [`tar-stream`](https://github.com/mafintosh/tar-stream)
+
+Use `finalize: false` and the `finish` hook to
+leave the pack stream open for further entries (see
+[`tar-stream#pack`](https://github.com/mafintosh/tar-stream#packing)),
+and use `pack` to pass an existing pack stream.
+
+``` js
+var mypack = tar.pack('./my-directory', {
+  finalize: false,
+  finish: function(sameAsMypack) {
+    mypack.entry({name: 'generated-file.txt'}, "hello")
+    tar.pack('./other-directory', {
+      pack: sameAsMypack
+    })
+  }
+})
+```
+
+
 ## Performance
 
 Packing and extracting a 6.1 GB with 2496 directories and 2398 files yields the following results on my Macbook Air.

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ exports.pack = function (cwd, opts) {
   var dmode = typeof opts.dmode === 'number' ? opts.dmode : 0
   var fmode = typeof opts.fmode === 'number' ? opts.fmode : 0
   var pack = opts.pack || tar.pack()
+  var finish = opts.finish || noop
 
   if (opts.strip) map = strip(map, opts.strip)
 
@@ -94,7 +95,10 @@ exports.pack = function (cwd, opts) {
 
   var onstat = function (err, filename, stat) {
     if (err) return pack.destroy(err)
-    if (!filename) return pack.finalize()
+    if (!filename) {
+      pack.finalize()
+      return finish(pack)
+    }
 
     if (stat.isSocket()) return onnextentry() // tar does not support sockets...
 
@@ -308,6 +312,8 @@ exports.extract = function (cwd, opts) {
       next()
     })
   })
+
+  if (opts.finish) extract.on('finish', opts.finish)
 
   return extract
 }

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ exports.pack = function (cwd, opts) {
   var onstat = function (err, filename, stat) {
     if (err) return pack.destroy(err)
     if (!filename) {
-      pack.finalize()
+      if (opts.finalize !== false) pack.finalize()
       return finish(pack)
     }
 


### PR DESCRIPTION
With this small change, you can merge multiple directories with different mapping rules into one archive, or add generated files after packing a directory.
Example usage:
```js
const path = require('path');
const fs = require('fs');
const tar = require('tar-fs');

var numEntries = 0

var pack = tar.pack('./package', {
  finalize: false,
  map(header) {
    numEntries++
    header.name = path.join('node_modules', 'package', header.name)
  },
  finish: addRest
})

function addRest() {
  pack.entry({name: 'info.txt'}, `Your dependencies have ${numEntries} files and folders`)

  tar.pack('./app', {
    pack: pack
  })
}

pack.pipe(fs.createWriteStream('archive.tar'))
```

I did my best to match code and test style.