### PR TITLE
Fix a typo in the code

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,7 @@ exports.extract = function (cwd, opts) {
 }
 
 function mkdirfix (name, opts, cb) {
-  mkdirp(name, {fs: opts.xfs}, function (err, made) {
+  mkdirp(name, {fs: opts.fs}, function (err, made) {
     if (!err && made && opts.own) {
       chownr(made, opts.uid, opts.gid, cb)
     } else {


### PR DESCRIPTION
### Problem:
When using the tar-fs with custom `fs`, the `mkdirp` method still use the standard `fs`. The root cause is a typo in `mkdirfix` method. The file system object is passed with `fs` option, but consumed through `xfs`.

### Fix:
Replace `xfs` with `fs` in `mkdirfix`.

