### PR TITLE
Maintain the context the stat call in case xfs is an ES6 class

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var statAll = function (fs, stat, cwd, ignore, entries, sort) {
     var next = queue.shift()
     var nextAbs = path.join(cwd, next)
 
-    stat(nextAbs, function (err, stat) {
+    fs[stat](nextAbs, function (err, stat) {
       if (err) return callback(err)
 
       if (!stat.isDirectory()) return callback(null, next, stat)
@@ -66,7 +66,7 @@ exports.pack = function (cwd, opts) {
   var ignore = opts.ignore || opts.filter || noop
   var map = opts.map || noop
   var mapStream = opts.mapStream || echo
-  var statNext = statAll(xfs, opts.dereference ? xfs.stat : xfs.lstat, cwd, ignore, opts.entries, opts.sort)
+  var statNext = statAll(xfs, opts.dereference ? 'stat' : 'lstat', cwd, ignore, opts.entries, opts.sort)
   var strict = opts.strict !== false
   var umask = typeof opts.umask === 'number' ? ~opts.umask : ~processUmask()
   var dmode = typeof opts.dmode === 'number' ? opts.dmode : 0


### PR DESCRIPTION
I'm using tar-fs with a custom in-memory FS implementation. However the https://github.com/MatrixAI/js-virtualfs is implemented with an ES6 class.

The current way of passing the `stat` or `lstat` function fails because passing it that way loses the `this` context. By instead using a string, we maintain the `this` context.  I ran the tests, and it still all works.