### PR TITLE
Fix typo in readme perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ var mypack = tar.pack('./my-directory', {
 Packing and extracting a 6.1 GB with 2496 directories and 2398 files yields the following results on my Macbook Air.
 [See the benchmark here](https://gist.github.com/mafintosh/8102201)
 
-* tar-fs: 34.261 ms
-* [node-tar](https://github.com/isaacs/node-tar): 366.123 ms (or 10x slower)
+* tar-fs: 34.261 seconds
+* [node-tar](https://github.com/isaacs/node-tar): 366.123 seconds (or 10x slower)
 
 ## License
 


### PR DESCRIPTION
The benchmark should probably be seconds instead of milliseconds