### PR TITLE
Improved directory permission handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.1.1",
   "description": "filesystem bindings for tar-stream",
   "dependencies": {
-    "chownr": "^1.1.1",
     "mkdirp-classic": "^0.5.2",
     "pump": "^3.0.0",
     "tar-stream": "^2.1.4"


### PR DESCRIPTION
Added improved support for directory permissions. Further the call to `chownr()` did not support custom `fs` objects, causing part of the operations to be done on the real filesystem instead of the given custom implementation. With this change we can also remove the chownr dependency.

My use case is working fine and unit tests are OK. Yet, I'm unsure if this will break something else I haven't thought of.