### PR TITLE
Add fix for early stream closure via pipeline

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ exports.pack = function pack (cwd, opts) {
   }
 
   function onstat (err, filename, stat) {
+    if (pack.destroyed) return
     if (err) return pack.destroy(err)
     if (!filename) {
       if (opts.finalize !== false) pack.finalize()


### PR DESCRIPTION
If the `readableStream` "pack" is closed via pipeline (eg the writable stream is closed instantly) before all the entries have been ingested, there is an error when `pack.entry` is called.

Thist pull just checks before calling `pack.entry` that the stream is still open.