### PR TITLE
Made `dmode`, `fmode` demo values shorter in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Set `options.fmode` and `options.dmode` to ensure that files/directories extract
 
 ``` js
 const extract = tar.extract('./my-directory', {
-  dmode: parseInt(555, 8), // all dirs should be readable
-  fmode: parseInt(444, 8) // all files should be readable
+  dmode: 0o555, // all dirs should be readable
+  fmode: 0o444 // all files should be readable
 })
 ```
 


### PR DESCRIPTION
The previous [#112](https://github.com/mafintosh/tar-fs/pull/112) PR seems to have no effect on the main branch, so resubmitting

```bash
node -e 'console.log(parseInt(255, 8) === 0o255)'
> true
```
